### PR TITLE
Fixed app blank on launch bug

### DIFF
--- a/front-end/public/manifest.json
+++ b/front-end/public/manifest.json
@@ -20,7 +20,7 @@
             "type": "image/png"
         }
     ],
-    "start_url": "./index.html",
+    "start_url": "/",
     "display": "standalone",
     "theme_color": "#3F8EDB",
     "background_color": "#3F8EDB"


### PR DESCRIPTION
When launching app from homescreen, the app shows a blank screen. This is because the app would try going to index.html, which doesn't match any routes. Now, the start_url is changed to / , which will take it to newsfeed.